### PR TITLE
Refactor Annotation Processor and add Converters

### DIFF
--- a/annotation-processor/build.gradle
+++ b/annotation-processor/build.gradle
@@ -5,16 +5,25 @@ plugins {
 
 group 'net.lostillusion.lostorm'
 
+ext {
+    kotlin_poet = '1.6.0'
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
     kapt 'com.google.auto.service:auto-service:1.0-rc4'
-    implementation "com.google.auto.service:auto-service:1.0-rc4"
-    implementation project(':annotations')
+    implementation 'com.google.auto.service:auto-service:1.0-rc4'
+    implementation "com.squareup:kotlinpoet:$kotlin_poet"
+    implementation "com.squareup:kotlinpoet-metadata:$kotlin_poet"
+    implementation "com.squareup:kotlinpoet-metadata-specs:$kotlin_poet"
+    implementation "com.squareup:kotlinpoet-classinspector-elements:$kotlin_poet"
     implementation project(':mapper')
-    implementation 'com.squareup:kotlinpoet:1.6.0'
+    implementation project(':annotations')
+    implementation 'io.github.microutils:kotlin-logging:1.12.0'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compile 'io.github.microutils:kotlin-logging:1.12.0'
     compile 'org.slf4j:slf4j-simple:1.7.30'

--- a/annotation-processor/gradle.properties
+++ b/annotation-processor/gradle.properties
@@ -1,2 +1,1 @@
-kapt.incremental.apt=true
 kapt.includeCompileClasspath = false

--- a/annotation-processor/src/main/kotlin/net/lostillusion/lostorm/annotationprocessor/AnnotationProcessor.kt
+++ b/annotation-processor/src/main/kotlin/net/lostillusion/lostorm/annotationprocessor/AnnotationProcessor.kt
@@ -2,29 +2,54 @@ package net.lostillusion.lostorm.annotationprocessor
 
 import com.google.auto.service.AutoService
 import com.squareup.kotlinpoet.*
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import mu.KotlinLogging
+import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
+import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
+import com.squareup.kotlinpoet.metadata.isObject
+import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import kotlinx.metadata.KmClassifier
 import net.lostillusion.lostorm.annotations.Columns
 import net.lostillusion.lostorm.annotations.EntityDataClass
-import net.lostillusion.lostorm.mapper.Column
-import net.lostillusion.lostorm.mapper.Entity
+import net.lostillusion.lostorm.annotations.ValueConverter
 import java.io.File
 import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
-import javax.lang.model.type.TypeKind
-import kotlin.reflect.KProperty1
+import javax.lang.model.type.MirroredTypeException
+import javax.lang.model.type.TypeMirror
+import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
+import kotlin.reflect.KClass
 
-@Suppress("unused")
+
+const val LOSTORM_PACKAGE = "net.lostillusion.lostorm.mapper"
+lateinit var types: Types
+lateinit var elements: Elements
+
+fun getColumnMemberName(typeName: TypeName): MemberName {
+    return when(typeName) {
+        String::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "text")
+        Boolean::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "bool")
+        Int::class.asTypeName() -> MemberName(LOSTORM_PACKAGE, "int")
+        Long::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "long")
+        Short::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "short")
+        Float::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "real")
+        Double::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "float")
+        Array<Byte>::class.asClassName() -> MemberName(LOSTORM_PACKAGE, "binary")
+        else -> throw Exception("Tried to get an invalid column member name, make sure you are using valid datatypes!")
+    }
+}
+
+@KotlinPoetMetadataPreview
+@ExperimentalStdlibApi
 @AutoService(Processor::class)
-class AnnotationProcessor : AbstractProcessor() {
+class AnnotationProcessor: AbstractProcessor() {
     companion object {
         const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
-        private val LOGGER = KotlinLogging.logger {}
     }
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()
@@ -33,130 +58,128 @@ class AnnotationProcessor : AbstractProcessor() {
         return mutableSetOf(EntityDataClass::class.java.name)
     }
 
+    override fun init(processingEnv: ProcessingEnvironment) {
+        super.init(processingEnv)
+        types = processingEnv.typeUtils
+        elements = processingEnv.elementUtils
+    }
+
     override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
-        roundEnv.getElementsAnnotatedWith(EntityDataClass::class.java).forEach(::processEntityAnnotation)
-        return false
+        roundEnv.getElementsAnnotatedWith(EntityDataClass::class.java).forEach(::processEntity)
+        return true
     }
 
     @Suppress("DEPRECATION")
-    private fun processEntityAnnotation(element: Element) {
-        val className = element.simpleName.toString()
-        val pack = processingEnv.elementUtils.getPackageOf(element).toString()
-        val tableName = element.getAnnotation(EntityDataClass::class.java).tableName.let {
-            if (it != "_none") it else "${className.toLowerCase()}table"
+    private fun processEntity(element: Element) {
+        //utility
+        fun extractTableName(): String = element.getAnnotation(EntityDataClass::class.java)!!.tableName.let {
+            if (it != "_none") it else "${element.simpleName.toString().toLowerCase()}table"
         }
-
-        val entityName = "${className}Entity"
-        val fileBuilder = FileSpec.builder(pack, entityName)
-        val entityBuilder = TypeSpec.objectBuilder(entityName)
-        entityBuilder.superclass(Entity::class.asTypeName().parameterizedBy(element.asType().asTypeName()))
-        entityBuilder.addSuperclassConstructorParameter("\"$tableName\"")
-        val columnsBuilder = PropertySpec.builder("columns", List::class.asTypeName().parameterizedBy(Column::class.asTypeName().parameterizedBy(STAR)))
-        columnsBuilder.addModifiers(KModifier.OVERRIDE)
-        val columns: MutableList<String> = mutableListOf()
-        val columnsToValuesBuilder =
-                PropertySpec.builder(
-                        "columnsToValues", Map::class.asTypeName().parameterizedBy(
-                        Column::class.asTypeName().parameterizedBy(STAR),
-                        KProperty1::class.asTypeName().parameterizedBy(element.asType().asTypeName(), STAR))
-                ).addModifiers(KModifier.OVERRIDE)
-        val ctvs = mutableListOf<String>()
-
-        for (enclosed in element.enclosedElements) {
-            if (enclosed.kind == ElementKind.FIELD) {
-                val config = enclosed.getAnnotation(Columns::class.java)
-                var columnName = enclosed.simpleName.toString()
-                if (config != null && config.columnName != "") columnName = config.columnName
-                var typeName: TypeName?
-                var initializer: String?
-                val initMember: MemberName?
-                when (enclosed.asType().kind) {
-                    TypeKind.DECLARED -> {
-                        when (Class.forName(enclosed.asType().toString()).kotlin) {
-                            String::class -> {
-                                typeName = Column::class.asTypeName().parameterizedBy(String::class.asTypeName().copy(nullable = config?.nullable == true))
-                                initializer = """%M("$columnName")"""
-                                initMember = MemberName("net.lostillusion.lostorm.mapper", "text")
-                            }
-                            else -> {
-                                throw UnsupportedEntityValueType("Declared value ${enclosed.simpleName} in $className cannot be converted to a column! Type found: ${enclosed.asType()}")
-                            }
-                        }
-                    }
-                    TypeKind.BOOLEAN -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Boolean::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "bool")
-                    }
-                    TypeKind.INT -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Int::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "int")
-                    }
-                    TypeKind.LONG -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Long::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "long")
-                    }
-                    TypeKind.SHORT -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Short::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "short")
-                    }
-                    TypeKind.FLOAT -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Float::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "real")
-                    }
-                    TypeKind.DOUBLE -> {
-                        typeName = Column::class.asTypeName().parameterizedBy(Double::class.asTypeName().copy(nullable = config?.nullable == true))
-                        initializer = """%M("$columnName")"""
-                        initMember = MemberName("net.lostillusion.lostorm.mapper", "float")
-                    }
-                    TypeKind.ARRAY -> {
-                        when (enclosed.asType().asTypeName()) {
-                            Array<Byte>::class.parameterizedBy(Byte::class) -> {
-                                typeName = Column::class.asTypeName().parameterizedBy(ByteArray::class.asTypeName().copy(nullable = config?.nullable == true))
-                                initializer = """%M("$columnName")"""
-                                initMember = MemberName("net.lostillusion.lostorm.mapper", "binary")
-                            }
-                            else -> {
-                                throw UnsupportedEntityValueType("Array ${enclosed.simpleName} in $className cannot be converted to a column! Type found: ${enclosed.asType()}")
-                            }
-                        }
-                    }
-                    else -> throw UnsupportedEntityValueType("Value ${enclosed.simpleName} in $className cannot be converted to a column! Type found: ${enclosed.asType().kind.name}")
-                }
-                if (config?.unique == true) initializer += ".unique()"
-                if (config?.nullable == true) initializer += ".nullable()"
-                if (config?.primaryKey == true) initializer += ".primary()"
-                columns.add(enclosed.simpleName.toString())
-                ctvs.add("${enclosed.simpleName} to ${className}::${enclosed.simpleName}")
-                PropertySpec.builder(enclosed.simpleName.toString(), typeName)
-                        .initializer(initializer, initMember)
-                        .mutable(false)
-                        .build()
-                        .let(entityBuilder::addProperty)
+        fun generateInitializer(property: Element): String {
+            val columnName = property
+                .getAnnotation(Columns::class.java)
+                ?.columnName
+                ?.let { if(it.isEmpty()) null else it }
+                ?: property.simpleName.toString()
+            return buildString {
+                append("""%M("$columnName")""")
+                property.getAnnotation(Columns::class.java)
+                    ?.let(ColumnProperty.Companion::fromColumns)
+                    ?.map(ColumnProperty::initializer)
+                    ?.forEach { append(it) }
+                if(property.getAnnotation(ValueConverter::class.java) != null) append(".converter(%M)")
             }
         }
-        columnsBuilder.initializer("listOf(${columns.joinToString(", ")})")
-        columnsToValuesBuilder.initializer("mapOf(${ctvs.joinToString(", ")})")
 
-        val dataClassFunBuilder = FunSpec.builder("createDataClass")
-                .addModifiers(KModifier.OVERRIDE)
-                .addParameter("values", List::class.asTypeName().parameterizedBy(STAR))
-                .addCode("return $className::class.constructors.first().call(*values.toTypedArray())")
-                .returns(element.asType().asTypeName())
+        val entityRenderer = EntityRenderer(
+            processingEnv.elementUtils.getPackageOf(element).toString(),
+            "${element.simpleName}Entity",
+            extractTableName(),
+            element.asType().asTypeName() as ClassName
+        )
 
-        entityBuilder.addFunction(dataClassFunBuilder.build())
-        entityBuilder.addProperty(columnsBuilder.build())
-        entityBuilder.addProperty(columnsToValuesBuilder.build())
+        val metadataProperties = (element as TypeElement).toImmutableKmClass().properties
 
-        fileBuilder.addType(entityBuilder.build())
+        for (property in element.enclosedElements) {
+            if(property.kind == ElementKind.FIELD) {
+                val typeArguments = processTypes(property) { metadataProperties.find { it.name == property.simpleName.toString() }!! }
+                val memberNames = mutableListOf<MemberName>()
+                typeArguments[0].let { memberNames.add(getColumnMemberName(it)) }
+                val converter = property.getAnnotationClassValue<ValueConverter> { converter }
+                converter
+                    ?.let(types::asElement)
+                    ?.let {
+                        memberNames.add(
+                            MemberName(
+                                elements.getPackageOf(it).qualifiedName.toString(),
+                                it.simpleName.toString()
+                            )
+                        )
+                    }
+                entityRenderer.addColumnRenderer(ColumnRenderer(
+                    property,
+                    typeArguments[0],
+                    typeArguments[1],
+                    generateInitializer(property),
+                    *memberNames.toTypedArray()
+                ))
+            }
+        }
+
         val kaptKotlinGeneratedDir = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME]
-        LOGGER.debug { "writing generated files to: $kaptKotlinGeneratedDir" }
-        fileBuilder.build().writeTo(File(kaptKotlinGeneratedDir!!))
+        entityRenderer.render().writeTo(File(kaptKotlinGeneratedDir!!))
     }
 }
 
-class UnsupportedEntityValueType(override val message: String) : Exception()
+sealed class ColumnProperty {
+    abstract val initializer: String
+
+    object UniqueProperty: ColumnProperty() {
+        override val initializer = ".unique()"
+    }
+    object PrimaryProperty: ColumnProperty() {
+        override val initializer = ".primary()"
+    }
+    object NullableProperty: ColumnProperty() {
+        override val initializer = ".nullable()"
+    }
+
+    companion object {
+        @ExperimentalStdlibApi
+        fun fromColumns(columns: Columns) = buildList {
+            if(columns.unique) add(UniqueProperty)
+            if(columns.primaryKey) add(PrimaryProperty)
+            if(columns.nullable) add(NullableProperty)
+        }
+    }
+}
+
+class ConverterNotAnObjectException(converter: TypeElement) : Exception("Converter ${converter.simpleName} is not an object and thus cannot be used!")
+
+@KotlinPoetMetadataPreview
+private fun processTypes(actual: Element, kmRetriever: () -> ImmutableKmProperty): List<ClassName> {
+    return if(actual.getAnnotation(ValueConverter::class.java) != null) {
+        val converter = types.asElement(actual.getAnnotationClassValue<ValueConverter> { converter }) as TypeElement
+        val converterKm = converter.toImmutableKmClass()
+        if(!converterKm.isObject) throw ConverterNotAnObjectException(converter)
+        val superConverter = converterKm.supertypes.find { (it.classifier as KmClassifier.Class).name == "net/lostillusion/lostorm/mapper/Converter" }!!
+        superConverter.arguments
+            .map { it.type!!.classifier as KmClassifier.Class }
+            .map { it.name.replace("/", ".") }
+            .map(ClassName.Companion::bestGuess)
+    } else {
+        val propertyKm = kmRetriever().returnType
+        val type = ClassName.bestGuess((propertyKm.classifier as KmClassifier.Class).name.replace("/", "."))
+        List(2) { type }
+    }
+}
+
+private inline fun <reified T : Annotation> Element.getAnnotationClassValue(crossinline f: T.() -> KClass<*>): TypeMirror? {
+    return try {
+        val annotation = getAnnotation(T::class.java) ?: return null
+        annotation.f()
+        throw Exception("Expected to get a MirroredTypeException!")
+    } catch (e: MirroredTypeException) {
+        e.typeMirror
+    }
+}

--- a/annotation-processor/src/main/kotlin/net/lostillusion/lostorm/annotationprocessor/Renderers.kt
+++ b/annotation-processor/src/main/kotlin/net/lostillusion/lostorm/annotationprocessor/Renderers.kt
@@ -1,0 +1,85 @@
+package net.lostillusion.lostorm.annotationprocessor
+
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import net.lostillusion.lostorm.mapper.Column
+import net.lostillusion.lostorm.mapper.Entity
+import javax.lang.model.element.Element
+import kotlin.reflect.KProperty1
+
+interface Renderer<T> {
+    fun render(): T
+}
+
+class ColumnRenderer(
+    property: Element,
+    private val sqlType: TypeName,
+    private val outputType: TypeName,
+    private val initializer: String,
+    private vararg val members: MemberName
+) : Renderer<PropertySpec> {
+    val name = property.simpleName.toString()
+
+    override fun render(): PropertySpec = PropertySpec.builder(name, Column::class.asTypeName().parameterizedBy(sqlType, outputType))
+        .initializer(initializer, *members)
+        .mutable(false)
+        .build()
+}
+
+class EntityRenderer(
+    private val packageName: String,
+    private val entityName: String,
+    private val tableName: String,
+    private val dataType: ClassName
+) : Renderer<FileSpec> {
+    private val columns = mutableListOf<ColumnRenderer>()
+
+    fun addColumnRenderer(columnRenderer: ColumnRenderer) { columns.add(columnRenderer) }
+
+    override fun render(): FileSpec {
+        val file = FileSpec.builder(packageName, entityName)
+        val entity = TypeSpec.objectBuilder(entityName)
+
+        entity.superclass(Entity::class.asTypeName().parameterizedBy(dataType))
+        entity.addSuperclassConstructorParameter(""""$tableName"""")
+
+        val columnsBuilder = generateColumnsList()
+        val columnsToValuesBuilder = generateColumnsToValuesMap()
+
+        val columnsInitializer = mutableListOf<String>()
+        val columnsToValuesInitializer = mutableListOf<String>()
+
+        for(columnRenderer in columns) {
+            columnsInitializer.add(columnRenderer.name)
+            columnsToValuesInitializer.add("${columnRenderer.name} to ${dataType.simpleName}::${columnRenderer.name}")
+            entity.addProperty(columnRenderer.render())
+        }
+
+        columnsBuilder.initializer("listOf(${columnsInitializer.joinToString(", ")}) as List<Column<Any, Any>>")
+        columnsToValuesBuilder.initializer("mapOf(\n${columnsToValuesInitializer.joinToString(", \n")}\n) as Map<Column<Any, Any>, KProperty1<Human, *>>")
+
+        entity.addFunction(generateCreateDataClass())
+        entity.addProperty(columnsBuilder.build())
+        entity.addProperty(columnsToValuesBuilder.build())
+
+        file.addType(entity.build())
+        return file.build()
+    }
+
+    private fun generateCreateDataClass() = FunSpec.builder("createDataClass")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter("values", List::class.asTypeName().parameterizedBy(STAR))
+        .addCode("return ${dataType.simpleName}::class.constructors.first().call(*values.toTypedArray())\n")
+        .returns(dataType)
+        .build()
+
+    private fun generateColumnsToValuesMap() = PropertySpec
+        .builder("columnsToValues", Map::class.asTypeName().parameterizedBy(
+            Column::class.parameterizedBy(Any::class, Any::class),
+            KProperty1::class.asTypeName().parameterizedBy(dataType, STAR)
+        )).addModifiers(KModifier.OVERRIDE)
+
+    private fun generateColumnsList() = PropertySpec
+        .builder("columns", List::class.asTypeName().parameterizedBy(Column::class.parameterizedBy(Any::class, Any::class)))
+        .addModifiers(KModifier.OVERRIDE)
+}

--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -10,6 +10,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation project(':mapper')
 }
 
 compileKotlin {

--- a/annotations/src/main/kotlin/net/lostillusion/lostorm/annotations/ValueConverter.kt
+++ b/annotations/src/main/kotlin/net/lostillusion/lostorm/annotations/ValueConverter.kt
@@ -1,0 +1,10 @@
+package net.lostillusion.lostorm.annotations
+
+import net.lostillusion.lostorm.mapper.Converter
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ValueConverter(
+    val converter: KClass<out Converter<*, *>>
+)

--- a/mapper/build.gradle
+++ b/mapper/build.gradle
@@ -9,10 +9,10 @@ repositories {
 }
 
 dependencies {
-    runtime 'org.jetbrains.kotlin:kotlin-reflect:1.3.72'
+    runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect:1.3.72'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    compile 'io.github.microutils:kotlin-logging:1.12.0'
-    compile 'org.slf4j:slf4j-simple:1.7.30'
+    implementation 'io.github.microutils:kotlin-logging:1.12.0'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
 }
 
 compileKotlin {

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Column.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Column.kt
@@ -2,27 +2,38 @@ package net.lostillusion.lostorm.mapper
 
 import kotlin.reflect.KClass
 
-class Column<T>(
+class Column<T: Any, B: Any>(
     val columnName: String,
     val isPrimary: Boolean = false,
     val hasDefaultValue: Boolean = false,
     val defaultValue: T? = null,
     val nullable: Boolean = false,
     val unique: Boolean = false,
-    val converter: (Any) -> T?,
+    val valueConverter: Converter<T, B>,
+    val sqlConverter: (Any) -> T?,
     val valueClass: KClass<out Any>
 ) {
-    fun primary() = Column<T>(columnName, true, hasDefaultValue, defaultValue, nullable, unique, converter, valueClass)
-    fun defaultValue(value: T) = Column<T>(columnName, isPrimary, true, value, nullable, unique, converter, valueClass)
-    fun nullable() = Column<T?>(columnName, isPrimary, hasDefaultValue, defaultValue, true, unique, converter, valueClass)
-    fun unique() = Column<T>(columnName, isPrimary, hasDefaultValue, defaultValue, nullable, true, converter, valueClass)
+    fun primary() = Column(columnName, true, hasDefaultValue, defaultValue, nullable, unique, valueConverter, sqlConverter, valueClass)
+    fun defaultValue(value: T) = Column(columnName, isPrimary, true, value, nullable, unique, valueConverter, sqlConverter, valueClass)
+    fun nullable() = Column(columnName, isPrimary, hasDefaultValue, defaultValue, true, unique, valueConverter, sqlConverter, valueClass)
+    fun unique() = Column(columnName, isPrimary, hasDefaultValue, defaultValue, nullable, true, valueConverter, sqlConverter, valueClass)
+    fun <R: Any> converter(converter: Converter<T, R>) = Column(columnName, isPrimary, hasDefaultValue, defaultValue, nullable, unique, converter, sqlConverter, valueClass)
 }
 
-fun bool(columnName: String) = Column(columnName, converter = { it as? Boolean }, valueClass = Boolean::class)
-fun int(columnName: String) = Column(columnName, converter = { it as? Int }, valueClass = Integer::class)
-fun text(columnName: String) = Column(columnName, converter = { it as? String }, valueClass = String::class)
-fun long(columnName: String) = Column(columnName, converter = { it as? Long}, valueClass = Long::class)
-fun short(columnName: String) = Column(columnName, converter = { it as? Short }, valueClass = Short::class)
-fun binary(columnName: String) = Column(columnName, converter = { it as? ByteArray }, valueClass = ByteArray::class)
-fun real(columnName: String) = Column(columnName, converter = { it as? Float }, valueClass = Float::class)
-fun float(columnName: String) = Column(columnName, converter = { it as? Double }, valueClass = Double::class)
+fun bool(columnName: String) = Column<Boolean, Boolean>(columnName, sqlConverter = { it as? Boolean }, valueConverter = DefaultConverter(), valueClass = Boolean::class)
+fun int(columnName: String) = Column<Int, Int>(columnName, sqlConverter = { it as? Int }, valueConverter = DefaultConverter(), valueClass = Integer::class)
+fun text(columnName: String) = Column<String, String>(columnName, sqlConverter = { it as? String }, valueConverter = DefaultConverter(), valueClass = String::class)
+fun long(columnName: String) = Column<Long, Long>(columnName, sqlConverter = { it as? Long}, valueConverter = DefaultConverter(), valueClass = Long::class)
+fun short(columnName: String) = Column<Short, Short>(columnName, sqlConverter = { it as? Short }, valueConverter = DefaultConverter(), valueClass = Short::class)
+fun binary(columnName: String) = Column<ByteArray, ByteArray>(columnName, sqlConverter = { it as? ByteArray }, valueConverter = DefaultConverter(), valueClass = ByteArray::class)
+fun real(columnName: String) = Column<Float, Float>(columnName, sqlConverter = { it as? Float }, valueConverter = DefaultConverter(), valueClass = Float::class)
+fun float(columnName: String) = Column<Double, Double>(columnName, sqlConverter = { it as? Double }, valueConverter = DefaultConverter(), valueClass = Double::class)
+
+fun <C: Any> bool(columnName: String, converter: Converter<Boolean, C>) = Column(columnName, sqlConverter = { it as? Boolean }, valueConverter = converter, valueClass = Boolean::class)
+fun <C: Any> int(columnName: String, converter: Converter<Int, C>) = Column(columnName, sqlConverter = { it as? Int }, valueConverter = converter, valueClass = Integer::class)
+fun <C: Any> text(columnName: String, converter: Converter<String, C>) = Column(columnName, sqlConverter = { it as? String }, valueConverter = converter, valueClass = String::class)
+fun <C: Any> long(columnName: String, converter: Converter<Long, C>) = Column(columnName, sqlConverter = { it as? Long}, valueConverter = converter, valueClass = Long::class)
+fun <C: Any> short(columnName: String, converter: Converter<Short, C>) = Column(columnName, sqlConverter = { it as? Short }, valueConverter = converter, valueClass = Short::class)
+fun <C: Any> binary(columnName: String, converter: Converter<ByteArray, C>) = Column(columnName, sqlConverter = { it as? ByteArray }, valueConverter = converter, valueClass = ByteArray::class)
+fun <C: Any> real(columnName: String, converter: Converter<Float, C>) = Column(columnName, sqlConverter = { it as? Float }, valueConverter = converter, valueClass = Float::class)
+fun <C: Any> float(columnName: String, converter: Converter<Double, C>) = Column(columnName, sqlConverter = { it as? Double }, valueConverter = converter, valueClass = Double::class)

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Converter.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Converter.kt
@@ -1,0 +1,13 @@
+package net.lostillusion.lostorm.mapper
+
+interface Converter<B: Any, T: Any> {
+    fun convertTo(value: B): T
+
+    fun convertFrom(from: T): B
+}
+
+class DefaultConverter<A: Any>: Converter<A, A> {
+    override fun convertTo(value: A): A = value
+
+    override fun convertFrom(from: A): A = from
+}

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Entity.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Entity.kt
@@ -6,15 +6,15 @@ import kotlin.reflect.KProperty1
 abstract class Entity<D: Any>(
     val tableName: String
 ) {
-    abstract val columns: List<Column<*>>
-    abstract val columnsToValues: Map<Column<*>, KProperty1<D, *>>
+    abstract val columns: List<Column<Any, Any>>
+    abstract val columnsToValues: Map<Column<Any, Any>, KProperty1<D, *>>
     val primaryKey by lazy { PrimaryKey(*columns.filter { it.isPrimary }.toTypedArray()) }
 
     abstract fun createDataClass(values: List<*>): D
 
     @Suppress("UNCHECKED_CAST")
     fun toEqExpressions(data: D): List<EqExpression<*>> =
-        columnsToValues.map { (it.key as Column<Any?>) eq it.value.get(data) }
+        columnsToValues.map { it.key eq it.value.get(data) }
 
     fun toExpression(data: D): Expression {
         val eqs = toEqExpressions(data).toMutableList()

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Expressions.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Expressions.kt
@@ -4,18 +4,18 @@ interface Expression {
     fun generateExpression(): String
 }
 
-class EqExpression<V>(
-    private val column: Column<V>,
-    private val value: V
+class EqExpression<V: Any>(
+    private val column: Column<*, V>,
+    private val value: V?
 ): Expression {
     override fun generateExpression() = "${column.columnName} = ${toSafeSQL(value)}"
 }
 
-class NeqExpression<V>(
-    private val column: Column<V>,
-    private val value: V
+class NeqExpression<V: Any>(
+    private val column: Column<*, V>,
+    private val value: V?
 ): Expression {
-    override fun generateExpression(): String = "${column.columnName} != $value"
+    override fun generateExpression(): String = "${column.columnName} != ${toSafeSQL(value)}"
 }
 
 class AndExpression(
@@ -25,10 +25,10 @@ class AndExpression(
     override fun generateExpression(): String = "${first.generateExpression()} and ${second.generateExpression()}"
 }
 
-infix fun <V> Column<V>.eq(value: V) =
+infix fun <V: Any> Column<*, V>.eq(value: V?) =
     EqExpression(this, value)
 
-infix fun <V> Column<V>.neq(value: V) =
+infix fun <V: Any> Column<*, V>.neq(value: V?) =
     NeqExpression(this, value)
 
 infix fun Expression.and(other: Expression) = AndExpression(this, other)

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/PrimaryKey.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/PrimaryKey.kt
@@ -1,7 +1,7 @@
 package net.lostillusion.lostorm.mapper
 
-class PrimaryKey(vararg val columns: Column<*>) {
-    val asSQL = columns.joinToString(", ", transform = Column<*>::columnName).let { 
+class PrimaryKey(vararg val columns: Column<*, *>) {
+    val asSQL = columns.joinToString(", ", transform = Column<*, *>::columnName).let {
         if(it.isEmpty()) ""
         else "primary key($it)"
     }

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/SchemaUtils.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/SchemaUtils.kt
@@ -12,14 +12,14 @@ object SchemaUtils {
                 val sql =
                     """create table if not exists ${it.tableName}
                         | (${
-                            it.columns.joinToString(", ") {
-                                """${it.columnName}
+                    it.columns.joinToString(", ") {
+                        """${it.columnName}
                                         | ${DataTypes.kotlinToSQL[it.valueClass]}
                                         |${if (it.nullable) "" else " not null"}
                                         |${if (it.hasDefaultValue) " default ${toSafeSQL(it.defaultValue)}" else ""}
                                     """.trimMargin()
-                            }
-                        }
+                    }
+                    }
                         |${if (it.primaryKey.asSQL.isNotEmpty()) ", ${it.primaryKey.asSQL}" else ""})
                     """.trimMargin()
                 LOGGER.debug { "Executing call: $sql" }

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/operations/Executors.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/operations/Executors.kt
@@ -29,7 +29,7 @@ class SelectExectutor<D : Any>(private val entity: Entity<D>) : OperationExecuto
             val currentResult = mutableListOf<Any?>()
             entity.columns.forEach {
                 try {
-                    currentResult += result.getObject(it.columnName)
+                    currentResult += it.valueConverter.convertTo(result.getObject(it.columnName))
                 } catch (e: SQLException) {
                     if (it.nullable) currentResult.add(null)
                     //TODO: Make this a unique exception


### PR DESCRIPTION
Splits up the logic between annotation processing and generating of files in the annotation processor.
Adds support for value converters.

closes #2 