### PR TITLE
v1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    kapt 'com.github.lost-illusi0n.lostorm:annotation-processor:1.3.2'
-    implementation 'com.github.lost-illusi0n.lostorm:mapper:1.3.2'
-    implementation 'com.github.lost-illusi0n.lostorm:annotations:1.3.2'
+    kapt 'com.github.lost-illusi0n.lostorm:annotation-processor:1.3.3'
+    implementation 'com.github.lost-illusi0n.lostorm:mapper:1.3.3'
+    implementation 'com.github.lost-illusi0n.lostorm:annotations:1.3.3'
 }
 ```
 ##### Maven

--- a/annotation-processor/build.gradle
+++ b/annotation-processor/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     kapt 'com.google.auto.service:auto-service:1.0-rc4'
+    runtime 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'com.google.auto.service:auto-service:1.0-rc4'
     implementation "com.squareup:kotlinpoet:$kotlin_poet"
     implementation "com.squareup:kotlinpoet-metadata:$kotlin_poet"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'net.lostillusion'
-version '1.3.2'
+version '1.3.3'
 
 repositories {
     jcenter()
@@ -21,7 +21,7 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'java'
     apply plugin: 'org.jetbrains.kotlin.jvm'
-    version '1.3.2'
+    version '1.3.3'
     publishing {
         repositories {
             maven {

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/PrimaryKey.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/PrimaryKey.kt
@@ -3,7 +3,7 @@ package net.lostillusion.lostorm.mapper
 /**
  * Represents an SQL Primary Key with the specified [columns].
  *
- * @param columns The [Column]s to be part of the Primay Key.
+ * @param columns The [Column]s to be part of the Primary Key.
  */
 class PrimaryKey(vararg val columns: Column<*, *>) {
     /**

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/SchemaUtils.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/SchemaUtils.kt
@@ -11,9 +11,10 @@ object SchemaUtils {
                 val sql = "create table if not exists ${entity.tableName} (" +
                     //add column information
                     entity.columns.joinToString(", ") { column ->
-                        "${column.columnName} ${DataTypes.kotlinToSQL[column.sqlClass]}" +              //column_name column_type
+                        ("${column.columnName} ${DataTypes.kotlinToSQL[column.sqlClass]}" +              //column_name column_type
                             (if(!column.nullable) " not null " else "") +                               //not null
                             (if(column.hasDefaultValue) " default ${column.defaultValue} " else "")     //default value
+                                ).trim()
                     } +
                     //primary key information
                     (if(entity.primaryKey.asSQL.isNotEmpty()) ", ${entity.primaryKey.asSQL}" else "") + //primary keys

--- a/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Session.kt
+++ b/mapper/src/main/kotlin/net/lostillusion/lostorm/mapper/Session.kt
@@ -13,7 +13,7 @@ import java.sql.DriverManager
  * @param driver The PostgreSQL driver (should usually not be changed).
  * @constructor Creates a session to the specified [host].
  */
-class Session(private val host: String, private val user: String, private val pass: String, driver: String = "org.postgresql.Driver") {
+class Session(private val host: String, private val user: String, private val pass: String?, driver: String = "org.postgresql.Driver") {
     init {
         Class.forName(driver)
     }


### PR DESCRIPTION
# Additions
- Add ``value in`` query for select statements
- Add a limit and offset clause
- Add helper methods using primary key for on conflict clauses

# Bug Fixes
- Fix incorrect SQL statement in ``SchemaUtil``
- Fix bug in select executor where it would error if a column is programmatically set to non-null but is null on the database side.